### PR TITLE
Fix expansion backprop

### DIFF
--- a/MCTS.py
+++ b/MCTS.py
@@ -260,9 +260,9 @@ def main():
                                 1, 2, 1, 2, 1, 2, 1])
     
     mcts = MCTS()
-    root_player_mark = 2
+    root_player_mark = 1
     training_dataset = []
-    player_one_move = mcts.search(alphazero_nn, 200, root_player_mark, mcts_test_board, training_dataset)
+    player_one_move = mcts.search(alphazero_nn, 500, root_player_mark, mcts_test_board, training_dataset)
     # should be between columns 0 to 6
     print(f"Player one next best move untrained: {player_one_move}")
 

--- a/MCTS.py
+++ b/MCTS.py
@@ -232,7 +232,8 @@ class MCTS():
 
         # do inversion here at the root node
         exp_z_score = root_node.total_z_score / root_node.visits
-        print(f"root node total z score: {root_node.total_z_score}")
+        if root_node.player_mark == 2: exp_z_score = (1 - exp_z_score)
+        print(f"root node total z score: {exp_z_score}")
         print(f"visits: {root_node.visits}")
 
         # if we maintain a 7 element vector throughout -> don't have to do this -> sub None instead for illegals
@@ -260,9 +261,9 @@ def main():
                                 1, 2, 1, 2, 1, 2, 1])
     
     mcts = MCTS()
-    root_player_mark = 1
+    root_player_mark = 2
     training_dataset = []
-    player_one_move = mcts.search(alphazero_nn, 500, root_player_mark, mcts_test_board, training_dataset)
+    player_one_move = mcts.search(alphazero_nn, 200, root_player_mark, mcts_test_board, training_dataset)
     # should be between columns 0 to 6
     print(f"Player one next best move untrained: {player_one_move}")
 

--- a/game_utils.py
+++ b/game_utils.py
@@ -3,7 +3,7 @@
 import numpy as np
 import NeuralNetwork
 # fix naming later
-from mcts import MCTS
+from MCTS import MCTS
 import mcts_utils
 
 CONNECT4_GRID = 42


### PR DESCRIPTION
Expansion fixed. A state board of player 2 represents a move 2 that has just been played on the board and a move 1 that is outgoing from the board onto a state of board of player 1. Exp z score also fixed. Need to still fix memory space for expansion (currently expanding all nodes at leaf node).